### PR TITLE
feat: introduce message streaming to block until the message is read …

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"dfs/p2p"
 	"fmt"
-	"io"
 	"log"
 	"time"
 )
@@ -33,25 +33,31 @@ func main() {
 	go func() {
 		log.Fatal(s1.Start())
 	}()
+
 	time.Sleep(2 * time.Second)
 	go s2.Start()
 	time.Sleep(2 * time.Second)
-	//data := bytes.NewReader([]byte("my big data file here!"))
-	//if err := s2.Store("myprivatekey", data); err != nil {
+
+	for i := 0; i < 10; i++ {
+		data := bytes.NewReader([]byte("my big data file here!"))
+		key := fmt.Sprintf("myprivatekey_%d", i)
+		if err := s2.Store(key, data); err != nil {
+			log.Fatal(err)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	//
+	//r, err := s2.Get("key that does not exist")
+	//if err != nil {
 	//	log.Fatal(err)
 	//}
-
-	r, err := s2.Get("myprivatekey")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	b, err := io.ReadAll(r)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(string(b))
+	//
+	//b, err := io.ReadAll(r)
+	//if err != nil {
+	//	log.Fatal(err)
+	//}
+	//
+	//fmt.Println(string(b))
 
 	select {}
 }

--- a/p2p/encoding.go
+++ b/p2p/encoding.go
@@ -20,6 +20,20 @@ type NOPDecoder struct {
 }
 
 func (dec NOPDecoder) Decode(r io.Reader, msg *RPC) error {
+	peekBuf := make([]byte, 1)
+
+	if _, err := r.Read(peekBuf); err != nil {
+		return nil
+	}
+
+	// In case of a stream, we are not decoding what is being sent over the network.
+	// We are just setting Stream true, so we can handle that in our logic
+	stream := peekBuf[0] == IncomingStream
+	if stream {
+		msg.Stream = true
+		return nil
+	}
+
 	buf := make([]byte, 1028)
 	n, err := r.Read(buf)
 	if err != nil {

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -1,6 +1,12 @@
 package p2p
 
+const (
+	IncomingMessage = 0x1
+	IncomingStream  = 0x2
+)
+
 type RPC struct {
 	From    string
 	Payload []byte
+	Stream  bool
 }

--- a/p2p/transporter.go
+++ b/p2p/transporter.go
@@ -12,6 +12,7 @@ type Peer interface {
 // between the notes in the network. This can be of the
 // for (TCP, UDP, Websockets, ...)
 type Transport interface {
+	Addr() string
 	Dial(string) error
 	ListenAndAccept() error
 	Consume() <-chan RPC


### PR DESCRIPTION
feat: introduce message streaming to block until the message is read and written to the network. Introduced a custom buffer that sets the streaming node which then allows us to manipulate the reading on the data from the remote networks, add more comments on each functionality for better understanding.